### PR TITLE
Fix 'Invalid non-ASCII or control character in header'

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-vp=4.0.0
+vp=4.0.1
 vs=
 AssemblyVersion=%vp%.0

--- a/src/app/Steinpilz.Owin.WebAssets/WebAssetsOwinHandler.cs
+++ b/src/app/Steinpilz.Owin.WebAssets/WebAssetsOwinHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,7 +82,7 @@ namespace Steinpilz.Owin.WebAssets
             if (processedAsset.Metadata.LastModifiedAt != null)
             {
                 context.Response.Headers.Append("Last-Modified",
-                    processedAsset.Metadata.LastModifiedAt.Value.ToUniversalTime().ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'")
+                    processedAsset.Metadata.LastModifiedAt.Value.ToUniversalTime().ToString("ddd, dd MMM yyyy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture)
                     );
             }
 


### PR DESCRIPTION
Fix 'Invalid non-ASCII or control character in header' exception in LastModifiedAt header for non latin languages